### PR TITLE
owl:inverseOf is separate from rdfs:label

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Comonly used, recommended or defined by this vocabulary. Everyone can use any ot
 These properties are grouped with the rdf:Property that names the relationship type.
 
 * label (rdfs:label)
-* inverse label (owl:inverseOf rdfs:label)
+* inverseOf (owl:inverseOf)
 * (need to add the source, target, context types.....)
 
 #### Examples


### PR DESCRIPTION
from my understanding, `owl:inverseOf` is actually referencing another `RelationshipType` that has an `rdfs:label` but may or may not have an `@id`. in Holodex, we separate out all of our inverse relationship types into objects with their own `@id`, so we wouldn't reference inverse labels inline like this.
